### PR TITLE
Fix issues with source map parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.3.3 / 2015-03-11
+
+### Highlights
+* Only parse source map once per CSS file, rather than on ever rule found in the stylesheet.
+* Paths in `results` where source maps are used are now reported relative to the location of the `.stylperjaderc` file
+
+### Changes
+[v0.3.2...v0.3.3](https://github.com/benedfit/stylperjade/compare/v0.3.2...v0.3.3)
+
 ## v0.3.2 / 2015-03-09
 
 ### Highlights

--- a/lib/stylperjade.js
+++ b/lib/stylperjade.js
@@ -224,8 +224,10 @@ function process(cssFiles, jadeFiles, options, cb) {
         return cb(err)
       }
 
+      var sourcemap = parseSourcemapFile(data, file)
+
       cssParser.parse(data, { silent: true, source: file }).stylesheet.rules.forEach(function (rule) {
-        processCssRule(rule, parseSourcemapFile(data, file))
+        processCssRule(rule, sourcemap)
       })
 
       cb()

--- a/lib/stylperjade.js
+++ b/lib/stylperjade.js
@@ -154,7 +154,8 @@ function process(cssFiles, jadeFiles, options, cb) {
     if (stylperjadercFile) options = parseConfigFile(stylperjadercFile)
 
     options = _.defaults(options
-      , { cssFiles: cssFiles || []
+      , { cwd: ''
+        , cssFiles: cssFiles || []
         , jadeFiles: jadeFiles || []
         , cssWhitelist: []
         , cssBlacklist: []
@@ -170,7 +171,11 @@ function process(cssFiles, jadeFiles, options, cb) {
   function parseConfigFile(file) {
 
     try {
-      return options = JSON.parse(JSON.minify(fs.readFileSync(file, 'utf-8')))
+      var options = JSON.parse(JSON.minify(fs.readFileSync(file, 'utf-8')))
+
+      options.cwd = path.dirname(file)
+
+      return options
     } catch (err) {
       if (err.code === 'ENOENT') err.message = 'Stylperjade: .stylperjaderc not found'
       if (err instanceof SyntaxError) throw new SyntaxError('Stylperjade: .stylperjaderc is invalid JSON')
@@ -313,7 +318,7 @@ function process(cssFiles, jadeFiles, options, cb) {
     if (sourcemap) {
       var sourcemapPosition = sourcemap.originalPositionFor({ 'line': line, 'column': column })
       if (sourcemapPosition) {
-        file = path.resolve(sourcemapPosition.source)
+        file = path.resolve(options.cwd, sourcemapPosition.source)
         line = sourcemapPosition.line
         column = sourcemapPosition.column
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylperjade",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Checks Jade for unused CSS classes",
   "author": "Ben Edwards <hello@benedfit.com>",
   "license": "ISC",


### PR DESCRIPTION
* Only parse source map once per CSS file, rather than on ever rule found in the stylesheet. This was causing Stylperjade to run really slowly in production environments
* Paths in `results` where source maps are used are now reported relative to the location of the `.stylperjaderc` file